### PR TITLE
[paau]: FiberMountain : Product Configuration with Variants

### DIFF
--- a/fiber-mountain/__init__.py
+++ b/fiber-mountain/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/fiber-mountain/__manifest__.py
+++ b/fiber-mountain/__manifest__.py
@@ -7,5 +7,5 @@
     "license": "OPL-1",
     "application": "False",
     "data": ["data/product_attribute.xml"],
-    "depends": ["sale_management"],
+    "depends": ["product"],
 }

--- a/fiber-mountain/__manifest__.py
+++ b/fiber-mountain/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    "name": "fiber-mountain",
+    "summary": "[paau]: FiberMountain : Product Configuration with Variants",
+    "category": "Training/FM",
+    "version": "18.0.0.0.1",
+    "author": "Austin Paskerian",
+    "license": "OPL-1",
+    "application": "False",
+    "data": ["data/product_attribute.xml"],
+    "depends": ["sale_management"],
+}

--- a/fiber-mountain/data/product_attribute.xml
+++ b/fiber-mountain/data/product_attribute.xml
@@ -1,0 +1,253 @@
+<odoo>
+
+    <!-- ________________BASE PRODUCT________________ -->
+
+    <record id="base_cable_product_template" model="product.template">
+        <field name="uom_category_id" ref="uom.uom_categ_length"/>
+        <field name="uom_id" ref="uom.product_uom_meter"/>
+        <field name="name">Base Cable</field>
+        <field name="list_price">0</field>
+        <field name="type">consu</field>
+    </record>
+
+    <!-- ________________FAMILY ATTRIBUTE________________ -->
+
+    <!-- Attr -->
+
+    <record id="cable_attribute_family" model="product.attribute">
+        <field name="name">Family</field>
+        <field name="create_variant">dynamic</field>
+    </record>
+
+    <!-- Vals -->
+
+    <record id="fam_f" model="product.attribute.value">
+        <field name="name">Fiber Cable</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_family"/>
+        <field name="code">F</field>
+
+    </record>
+
+    <record id="fam_g" model="product.attribute.value">
+        <field name="name">GSA Listed Fiber Cable</field>
+        <field name="default_extra_price">15</field>
+        <field name="attribute_id" ref="cable_attribute_family"/>
+        <field name="code">G</field>
+    </record>
+
+    <!-- Attr line -->
+
+    <record id="cable_attribute_family_line" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="base_cable_product_template"/>
+
+        <field name="attribute_id" ref="cable_attribute_family"/>
+        <field name="value_ids" eval="[(6, 0, [ref('fam_f'), ref('fam_g')])]"/>
+    </record>
+
+    <!-- ________________CONNECTOR CAPABILITY ATTRIBUTE________________ -->
+
+    <!-- Attr -->
+
+    <record id="cable_attribute_connector_capability" model="product.attribute">
+        <field name="name">Connector Capability</field>
+        <field name="create_variant">dynamic</field>
+    </record>
+
+    <!-- Vals -->
+
+    <record id="cap_n" model="product.attribute.value">
+        <field name="name">Non ICID</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_capability"/>
+        <field name="code">N</field>
+    </record>
+
+    <record id="cap_s" model="product.attribute.value">
+        <field name="name">Gen1 ICID</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_capability"/>
+        <field name="code">S</field>
+    </record>
+
+    <!-- Attr line -->
+
+    <record id="cable_attribute_connector_capablity_line" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="base_cable_product_template"/>
+
+        <field name="attribute_id" ref="cable_attribute_connector_capability"/>
+        <field name="value_ids" eval="[(6, 0, [ref('cap_n'), ref('cap_s')])]"/>
+    </record>
+
+
+    <!-- ________________FIBER TYPE ATTRIBUTE________________ -->
+
+    <!-- Attr -->
+
+    <record id="cable_attribute_fiber_type" model="product.attribute">
+        <field name="name">Fiber Type</field>
+        <field name="create_variant">dynamic</field>
+    </record>
+
+    <!-- Vals -->
+
+    <record id="type_s" model="product.attribute.value">
+        <field name="name">OS2</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_fiber_type"/>
+        <field name="code">S</field>
+    </record>
+
+    <record id="type_m" model="product.attribute.value">
+        <field name="name">OM4</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_fiber_type"/>
+        <field name="code">M</field>
+    </record>
+
+    <record id="type_5" model="product.attribute.value">
+        <field name="name">OM5</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_fiber_type"/>
+        <field name="code">5</field>
+    </record>
+
+    <!-- Attr line -->
+
+    <record id="cable_attribute_fiber_type_line" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="base_cable_product_template"/>
+        <field name="attribute_id" ref="cable_attribute_fiber_type"/>
+        <field name="value_ids" eval="[(6, 0, [ref('type_s'), ref('type_m'),ref('type_5')])]"/>
+    </record>
+
+
+    <!-- ________________FIBER COUNT ATTRIBUTE________________ -->
+
+    <!-- Attr -->
+
+    <record id="cable_attribute_fiber_count" model="product.attribute">
+        <field name="name">Fiber Count</field>
+        <field name="create_variant">dynamic</field>
+    </record>
+
+    <!-- Vals -->
+
+    <record id="count_1" model="product.attribute.value">
+        <field name="name">01</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_fiber_count"/>
+        <field name="code">01</field>
+    </record>
+
+    <record id="count_2" model="product.attribute.value">
+        <field name="name">02</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_fiber_count"/>
+        <field name="code">02</field>
+    </record>
+
+
+    <record id="count_8" model="product.attribute.value">
+        <field name="name">08</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_fiber_count"/>
+        <field name="code">08</field>
+    </record>
+
+
+    <!-- Attr line -->
+
+    <record id="cable_attribute_fiber_count_line" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="base_cable_product_template"/>
+        <field name="attribute_id" ref="cable_attribute_fiber_count"/>
+        <field name="value_ids" eval="[(6, 0, [ref('count_1'), ref('count_2'),ref('count_8')])]"/>
+    </record>
+
+
+    <!-- ________________CONNECTOR A ATTRIBUTE________________ -->
+
+    <!-- Attr -->
+
+    <record id="cable_attribute_connector_a" model="product.attribute">
+        <field name="name">Connector A</field>
+        <field name="create_variant">dynamic</field>
+    </record>
+
+    <!-- Vals -->
+
+    <record id="ca_8" model="product.attribute.value">
+        <field name="name">MP08 Unpinned</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_a"/>
+        <field name="code">MF8</field>
+    </record>
+
+    <record id="ca_12" model="product.attribute.value">
+        <field name="name">MP012 Unpinned</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_a"/>
+        <field name="code">MF12</field>
+    </record>
+
+
+    <record id="ca_24" model="product.attribute.value">
+        <field name="name">MP024 Unpinned</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_a"/>
+        <field name="code">MF24</field>
+    </record>
+
+
+    <!-- Attr line -->
+
+    <record id="cable_attribute_connector_a_line" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="base_cable_product_template"/>
+        <field name="attribute_id" ref="cable_attribute_connector_a"/>
+        <field name="value_ids" eval="[(6, 0, [ref('ca_8'), ref('ca_12'),ref('ca_24')])]"/>
+    </record>
+
+
+    <!-- ________________CONNECTOR A ATTRIBUTE________________ -->
+
+    <!-- Attr -->
+
+    <record id="cable_attribute_connector_b" model="product.attribute">
+        <field name="name">Connector B</field>
+        <field name="create_variant">dynamic</field>
+    </record>
+
+    <!-- Vals -->
+
+    <record id="ca_8b" model="product.attribute.value">
+        <field name="name">MP08 Unpinned</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_b"/>
+        <field name="code">MF8</field>
+    </record>
+
+    <record id="ca_12b" model="product.attribute.value">
+        <field name="name">MP012 Unpinned</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_b"/>
+        <field name="code">MF12</field>
+    </record>
+
+
+    <record id="ca_24b" model="product.attribute.value">
+        <field name="name">MP024 Unpinned</field>
+        <field name="default_extra_price">10</field>
+        <field name="attribute_id" ref="cable_attribute_connector_b"/>
+        <field name="code">MF24</field>
+    </record>
+
+
+    <!-- Attr line -->
+
+    <record id="cable_attribute_connector_b_line" model="product.template.attribute.line">
+        <field name="product_tmpl_id" ref="base_cable_product_template"/>
+        <field name="attribute_id" ref="cable_attribute_connector_b"/>
+        <field name="value_ids" eval="[(6, 0, [ref('ca_8b'), ref('ca_12b'),ref('ca_24b')])]"/>
+    </record>
+
+
+</odoo>

--- a/fiber-mountain/models/__init__.py
+++ b/fiber-mountain/models/__init__.py
@@ -1,0 +1,1 @@
+from . import product_attribute_value, product_product

--- a/fiber-mountain/models/product_attribute_value.py
+++ b/fiber-mountain/models/product_attribute_value.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class ProductAttributeValue(models.Model):
+    _inherit = "product.attribute.value"
+
+    # Code field to build the variant name from
+    code = fields.Char(string="Code")

--- a/fiber-mountain/models/product_product.py
+++ b/fiber-mountain/models/product_product.py
@@ -1,0 +1,35 @@
+from odoo import models, api
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+
+        # I copied what the create method does, and then added some functionality
+        products = super(
+            ProductProduct, self.with_context(create_product_product=False)
+        ).create(vals_list)
+        self.env.registry.clear_cache()
+
+        # Change the reference codes for each unique types
+        for p in products:
+            # Extract the attribute value IDs from the product that was created to build code
+            attr_ids = p.product_template_attribute_value_ids
+
+            # Indicies to insert hyphens
+            hyphens = (3, 4)
+
+            # Build the ref code for the unique product
+            name = ""
+            for i in range(len(attr_ids)):
+                name += attr_ids[i].product_attribute_value_id.code
+
+                if i in hyphens:
+                    name += "-"
+
+            # Set code for variant
+            p.default_code = name
+
+        return products

--- a/fiber-mountain/models/product_product.py
+++ b/fiber-mountain/models/product_product.py
@@ -11,7 +11,6 @@ class ProductProduct(models.Model):
         products = super(
             ProductProduct, self.with_context(create_product_product=False)
         ).create(vals_list)
-        self.env.registry.clear_cache()
 
         # Change the reference codes for each unique types
         for p in products:


### PR DESCRIPTION
https://www.odoo.com/odoo/6486/tasks/4710310

I added records in product_attribute.xml to reflect the attributes for the cable product from the table on the task. I didnt make all of them since there are dozens but enough to demonstrate the required functionality

For quantities, since it would be silly to create individual base prices for each attribute for each UOM like the task says, i made the product default to meters, so that when you change the length/quantity it will just scale all the prices appropriately.

Product variants like this are created when you configure one on a quotation
![Screenshot from 2025-05-21 10-42-49](https://github.com/user-attachments/assets/915c4d06-cd93-4426-9019-bce56cbf0a00)

Heres the configurator, prices can be set for each attribute to whatever is needed, and quantity is the default uom meters:
![Screenshot from 2025-05-21 10-44-15](https://github.com/user-attachments/assets/d25ada3a-a5b5-41ed-bd8b-d3c63f748b76)

Again did not add all the product attributes but you get the idea for the code formatting requirement:
![Screenshot from 2025-05-21 10-46-07](https://github.com/user-attachments/assets/fe35f669-3c01-4a78-a1e9-85f613cdab3a)

